### PR TITLE
Added env to ensure python2 is used to run

### DIFF
--- a/domain_scavenge.py
+++ b/domain_scavenge.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python2
+
 import os
 import hashlib
 import urllib2


### PR DESCRIPTION
Nothing ground breaking, I just added #!/usr/bin/env python2 at the top as when you run with python3 you get this bs selection tool.
